### PR TITLE
Update build.yml to macos-latest and add workflow_dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     types: [opened, synchronize]
     branches: [main, dev]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
I got completely working builds from this. Also, workflow_dispatch allows for manual building (instead of needing to make dummy pull requests) but I think it will only show up once dev gets merged to main.