### PR TITLE
Add skip wait button to bootstrapper loading screen AND Change fps limit to a slider and support 120hz battery saving mode AND fix bootstrap binary path and bunx resolution in build scripts.

### DIFF
--- a/frontend/src/windows/bootstrapper/App.svelte
+++ b/frontend/src/windows/bootstrapper/App.svelte
@@ -14,6 +14,17 @@
 	let text = 'Initializing...';
 	let theme: ParsedTheme | null = null;
 	let assetsDir = '';
+	let waitRemoved = false;
+
+	async function handleSkipWait() {
+		waitRemoved = true;
+		try {
+			await events.broadcast('bootstrapper:skip_wait');
+			Logger.info('Bootstrapper: Broadcasted skip_wait event.');
+		} catch (e) {
+			Logger.error('Bootstrapper: Failed to broadcast skip_wait:', e);
+		}
+	}
 
 	const params = new URLSearchParams(window.location.search);
 
@@ -186,6 +197,19 @@
 			<ThemeElement {el} {text} {progress} {resolveThemeUrl} />
 		{/each}
 		</div>
+		{#if !waitRemoved}
+			<button
+				on:click={handleSkipWait}
+				class="absolute bottom-2 left-1/2 -translate-x-1/2 z-50 text-[11px] px-3 py-1 rounded-full bg-black/60 hover:bg-black/80 text-white backdrop-blur-sm transition-all cursor-pointer border border-white/10"
+				id="themed_skip_wait_btn"
+			>
+				Dont want to wait any longer? Click to remove the wait
+			</button>
+		{:else}
+			<p class="absolute bottom-2 left-1/2 -translate-x-1/2 z-50 text-[11px] px-3 py-1 rounded-full bg-black/60 text-white/70 backdrop-blur-sm animate-pulse border border-white/10">
+				Removing wait...
+			</p>
+		{/if}
 	</div>
 
 {:else}
@@ -209,9 +233,23 @@
 
 			<p class="text-[3vmin] text-foreground/70 font-medium tracking-wider mb-[2vh]">AppleBlox Bootstrapper</p>
 
-			<p class="text-[2.5vmin] text-foreground/50 font-mono">
+			<p class="text-[2.5vmin] text-foreground/50 font-mono mb-[1.5vh]">
 				{Math.round(progress)}%
 			</p>
+
+			{#if !waitRemoved}
+				<button
+					on:click={handleSkipWait}
+					class="text-[2.2vmin] text-primary/80 hover:text-primary hover:underline transition-all cursor-pointer font-medium"
+					id="skip_wait_btn"
+				>
+					Dont want to wait any longer? Click to remove the wait
+				</button>
+			{:else}
+				<p class="text-[2.2vmin] text-muted-foreground font-medium animate-pulse">
+					Removing wait...
+				</p>
+			{/if}
 		</div>
 	</div>
 {/if}

--- a/frontend/src/windows/main/pages/Engine.svelte
+++ b/frontend/src/windows/main/pages/Engine.svelte
@@ -16,12 +16,15 @@
 				.setName('Graphics Engine')
 				.setDescription('Core graphics and performance settings')
 				.setId('graphics')
-				.addSwitch({
-					label: 'Remove Frame Rate Limit',
+				.addSlider({
+					label: 'Frame Rate Limit',
 					description:
-						'Create a 240hz virtual display that will let you go above your monitor\'s refresh rate in game.',
-					id: 'fps_cap',
-					default: false,
+						'Set your max FPS (0 = default 60hz limit). Values above 60hz will create a virtual display to bypass macOS v-sync limits. (120hz is great for battery saving)',
+					id: 'fps_limit',
+					default: 0,
+					min: 0,
+					max: 240,
+					step: 10,
 				})
 				// .addSelect({
 				// 	label: 'Render Resolution',

--- a/frontend/src/windows/main/ts/roblox/launch.ts
+++ b/frontend/src/windows/main/ts/roblox/launch.ts
@@ -2,7 +2,7 @@ import { events, app as neuApp, window as neuWindow, os, filesystem, server } fr
 import beautify from 'json-beautify';
 import path from 'path-browserify';
 import { toast } from 'svelte-sonner';
-import { getValue } from '../../components/settings';
+import { getValue, setValue } from '../../components/settings';
 import { libraryPath } from '../libraries';
 import { Notification } from '../tools/notifications';
 import { RPCController } from '../tools/rpc';
@@ -47,6 +47,7 @@ let rbxInstance: RobloxInstance | null = null;
 let bootstrapperProcess: SpawnEventEmitter | null = null;
 let virtualdisplayProcess: SpawnEventEmitter | null = null;
 let initialProgressListener: ((evt: { detail: string }) => Promise<void>) | null = null;
+let skipWaitListener: (() => Promise<void>) | null = null;
 
 interface LaunchSettings {
 	areModsEnabled: boolean;
@@ -306,6 +307,17 @@ async function setupBootstrapper(): Promise<void> {
 	};
 	events.on('bootstrapper:ready', initialProgressListener);
 
+	skipWaitListener = async () => {
+		logger.info('Received bootstrapper:skip_wait event, disabling fixed loading delays');
+		_allowFixedDelays = false;
+		try {
+			await setValue('misc.advanced.allow_fixed_loading_times', false);
+		} catch (err) {
+			logger.warn('Failed to update allow_fixed_loading_times setting:', err);
+		}
+	};
+	events.on('bootstrapper:skip_wait', skipWaitListener);
+
 	await sleep(500);
 }
 
@@ -329,6 +341,13 @@ async function cleanupBootstrapper(): Promise<void> {
 			await events.off('bootstrapper:ready', initialProgressListener);
 		} catch {}
 		initialProgressListener = null;
+	}
+
+	if (skipWaitListener) {
+		try {
+			await events.off('bootstrapper:skip_wait', skipWaitListener);
+		} catch {}
+		skipWaitListener = null;
 	}
 
 	if (bootstrapperProcess) {

--- a/frontend/src/windows/main/ts/roblox/launch.ts
+++ b/frontend/src/windows/main/ts/roblox/launch.ts
@@ -487,9 +487,15 @@ async function applyModsAndLaunch(settings: LaunchSettings, robloxUrl?: string):
 	await updateBootstrapper('bootstrapper:progress', { progress: 100 });
 	if (await getAllowFixedDelays()) await sleep(FIXED_STEP_DELAY);
 
-	if ((await getValue<boolean>('engine.graphics.fps_cap')) === true) {
+	let fpsLimit = await getValue<number>('engine.graphics.fps_limit');
+	if (fpsLimit === undefined || typeof fpsLimit === 'boolean') {
+		const oldFpsCap = await getValue<boolean>('engine.graphics.fps_cap');
+		fpsLimit = oldFpsCap ? 240 : 0;
+	}
+
+	if (fpsLimit && fpsLimit > 60) {
 		const vdPath = libraryPath('virtualdisplay');
-		logger.info('FPS cap enabled: starting virtual display');
+		logger.info(`FPS limit > 60 (${fpsLimit}): starting virtual display`);
 		virtualdisplayProcess = await spawn(vdPath, ['--no-menu'], { skipStderrCheck: true });
 		virtualdisplayProcess.on('exit', () => {
 			virtualdisplayProcess = null;
@@ -572,6 +578,16 @@ export async function launchRoblox(
 
 	try {
 		const fflags = await validateFlags(showFlagErrorPopup, checkFlags);
+
+		let fpsLimitLaunch = await getValue<number>('engine.graphics.fps_limit');
+		if (fpsLimitLaunch === undefined || typeof fpsLimitLaunch === 'boolean') {
+			const oldFpsCap = await getValue<boolean>('engine.graphics.fps_cap');
+			fpsLimitLaunch = oldFpsCap ? 240 : 0;
+		}
+
+		if (fpsLimitLaunch && fpsLimitLaunch > 0) {
+			fflags['DFIntTaskSchedulerTargetFps'] = fpsLimitLaunch.toString();
+		}
 
 		if (!robloxUrl) await setWindowVisibility(false);
 		await setupBootstrapper();

--- a/scripts/build/ts/mac-bundle.ts
+++ b/scripts/build/ts/mac-bundle.ts
@@ -79,7 +79,7 @@ export async function macBuildSingle(arch: string, distPath: string, librariesPa
 		await generateInfoPlist(appDist, logger);
 
 		// Copy executables with proper permissions
-		await copyExecutables(appDist, executable, logger);
+		await copyExecutables(appDist, executable, arch, logger);
 
 		// Copy resources
 		await copyResources(appDist, neuResources, logger);
@@ -167,12 +167,15 @@ async function generateInfoPlist(appDist: string, logger: Signale) {
 	logger.success('Generated Info.plist');
 }
 
-async function copyExecutables(appDist: string, executable: string, logger: Signale) {
+async function copyExecutables(appDist: string, executable: string, arch: string, logger: Signale) {
 	const appBundle = `${BuildConfig.appName}.app`;
 	const MacOS = resolve(appDist, appBundle, 'Contents', 'MacOS');
 	const mainPath = resolve(MacOS, 'main');
 	const bootstrapPath = resolve(MacOS, 'bootstrap');
-	const bootstrapSource = resolve('bin/bootstrap_ablox');
+	// Try arch-specific path first, then fall back to root bin/ for backwards compatibility
+	const bootstrapSource = existsSync(resolve(`bin/${arch}/bootstrap_ablox`))
+		? resolve(`bin/${arch}/bootstrap_ablox`)
+		: resolve('bin/bootstrap_ablox');
 
 	// Copy main executable with retry
 	await executeWithRetry(

--- a/scripts/build/ts/utils.ts
+++ b/scripts/build/ts/utils.ts
@@ -5,7 +5,7 @@ import { Signale } from 'signale';
 
 export async function buildViteAndNeu(buildVite = true) {
 	if (!(await checkNeutralino())) {
-		await $`bunx neu update`;
+		await $`./node_modules/.bin/neu update`;
 	}
 
 	const frontBuildLog = new Signale({
@@ -18,7 +18,7 @@ export async function buildViteAndNeu(buildVite = true) {
 		await $`rm -rf "${resolve('frontend/dist')}"`;
 
 		try {
-			await $`bunx vite build`;
+			await $`./node_modules/.bin/vite build`;
 
 			// Wait for build completion
 			let attempts = 0;
@@ -46,7 +46,7 @@ export async function buildViteAndNeu(buildVite = true) {
 	await sleep(500);
 
 	try {
-		await $`bunx neu build`;
+		await $`./node_modules/.bin/neu build`;
 	} catch (err) {
 		frontBuildLog.fatal('Neutralino build failed:');
 		frontBuildLog.fatal(err);


### PR DESCRIPTION
The wait shouldnt be there (still there but has a button to remove)